### PR TITLE
Add support for filestorage testing

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -82,6 +82,13 @@ fio:
     disk-devices:
       type: string
       description: "If unset, use the charm default rbd device in the ceph pool or the block devices provided using test-devices storage. If set run fio, against the set disk. Space delimited list of devices."
+    files:
+      type: string
+      description: |
+        Space delimited list of filenames that fio will lay out for testing. If not
+        specified, a single file will be created; its name will be derived from the
+        unit name. The files will be laid out in the directories specified in the 
+        `directories` config option.
     pool-name:
       type: string
       description: "If using the default rbd device, name of ceph pool for test. Defaults to config option pool-name"

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,19 @@ options:
     default:
     description: |
       Space delimted list of block devices.
+  directories:
+    type: string
+    default:
+    description: |
+      Space delimited list of directories where fio lays out files.
+  filesize:
+    type: string
+    default: 1G
+    description: |
+      The size of a file laid out by fio. This is taken into account only if
+      `directories` config option is defined. For more information about the 
+      fio's `filesize` option, see fio upstream documentation: 
+      https://fio.readthedocs.io/en/latest/fio_doc.html#cmdoption-arg-filesize
   pool-name:
     type: string
     default: ceph-benchmarking

--- a/templates/disk.fio
+++ b/templates/disk.fio
@@ -18,8 +18,16 @@ runtime=120
 {% else %}
 runtime=30
 {% endif %}
+{% if action_params.disk_devices %}
 {% for dev in action_params.disk_devices %}
 [job {{loop.index}}]
 filename={{dev}}
 {% endfor %}
+{% elif action_params.files %}
+{% for file in action_params.files %}
+[job {{loop.index}}]
+filename={{file}}
+filesize={{action_params.filesize}}
+{% endfor %}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
This PR allows Woodpecker charm to handle filestorage instead of just block storage. The idea is to be able to benchmark Manilla-Ganesha or other RWM file-systems.

The example below triggers fio tests using /mnt/nfs/woodpecker-0 file.
```
# Tell woodpecker where the files for fio testing should be laid out
juju config woodpecker directories=/mnt/nfs

# Mount a NFS share in woodpecker unit
juju run --application woodpecker "sudo mount -t nfs ${SHARE} /mnt/nfs/"

# Run fio test with a 10GB file
juju run-action woodpecker/0 \
  fio operation=randwrite runtime=60 block-size=4k filesize=10G
```

