### PR TITLE
Make template rendering take operation type into account

### DIFF
--- a/templates/disk.fio
+++ b/templates/disk.fio
@@ -1,7 +1,12 @@
 {% if action_params %}
 [global]
 ioengine={{ action_params.ioengine }}
+{% if 'read' in action_params.operation %}
+iodepth=1
+time_based=1
+{% else %}
 iodepth={{ action_params.iodepth }}
+{% endif %}
 direct=1
 rw={{ action_params.operation }}
 random_generator=lfsr

--- a/templates/rbd.fio
+++ b/templates/rbd.fio
@@ -16,5 +16,10 @@ latency_window={{ action_params.latency_window }}
 latency_percentile={{ action_params.latency_percentile }}
 {% endif %}
 [rbd_iodepth32]
+{% if 'read' in action_params.operation %}
+iodepth=1
+time_based=1
+{% else %}
 iodepth={{ action_params.iodepth }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
As per the following: https://bugs.launchpad.net/charm-woodpecker/+bug/1940371

Reads should be using a different set of parameters (namely, iodepth=1 and time_based=1), to prevent skewed results in
benchmarking. This PR does it by introducing some logic changes in the templates used.