### PR TITLE
Support for Erasure Coded pools fio benchmarking

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -85,6 +85,13 @@ fio:
     pool-name:
       type: string
       description: "If using the default rbd device, name of ceph pool for test. Defaults to config option pool-name"
+    ec-pool-name:
+      type: string
+      description: |
+          Optional. 
+          Used during creation of RBD image to benchmark Erasure Coded pools (--data-pool).
+          Erasure coded pool must exists before running fio action.
+          This pool must also have rbd application enabled, and `allow_ec_overwrites` set to true.
     image-size:
       type: integer
       default: 20480

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,29 @@
+type: charm
+
+parts:
+  charm:
+    after: [update-certificates]
+    build-packages: [python3-markupsafe, git]
+    charm-python-packages: [setuptools < 58]
+
+  update-certificates:
+    plugin: nil
+    # See https://github.com/canonical/charmcraft/issues/658
+    override-build: |
+      apt update
+      apt install -y ca-certificates
+      update-ca-certificates
+
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures:
+          - amd64
+    run-on:
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64, s390x, ppc64el, arm64]
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64, s390x, ppc64el, arm64]

--- a/src/bench_tools.py
+++ b/src/bench_tools.py
@@ -21,10 +21,16 @@ class BenchTools():
         _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
         return _output.decode("UTF-8")
 
-    def rbd_create_image(self, pool_name, image_size):
+    def rbd_remove_image(self, pool_name):
+        _cmd = ["rbd", "remove", self.charm_instance.RBD_IMAGE,
+                "-p", pool_name, "-n", self.charm_instance.CEPH_CLIENT_NAME]
+        _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
+        return _output.decode("UTF-8")
+
+    def rbd_create_image(self, pool_name, image_size, extra_args=[]):
         _cmd = ["rbd", "create", self.charm_instance.RBD_IMAGE,
                 "--size", str(image_size), "-p", pool_name,
-                "-n", self.charm_instance.CEPH_CLIENT_NAME]
+                "-n", self.charm_instance.CEPH_CLIENT_NAME] + extra_args
         _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
         return _output.decode("UTF-8")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,6 +2,7 @@
 
 from base64 import b64decode
 import datetime
+import errno
 import hashlib
 import json
 import socket
@@ -590,14 +591,13 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             )
             logging.info("rbd image removed")
         except subprocess.CalledProcessError as e:
-            if "No such file or directory" in e.stderr.decode("UTF-8"):
+            if e.returncode == errno.ENOENT:
                 pass
             else:
                 _msg = ("rbd remove image failed: {}"
                         .format(e.stderr.decode("UTF-8")))
                 logging.error(_msg)
                 event.fail(_msg)
-                event.set_results({"stderr": _msg, "code": "1"})
                 raise
 
         # Create the image
@@ -621,7 +621,6 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
                     .format(e.stderr.decode("UTF-8")))
             logging.error(_msg)
             event.fail(_msg)
-            event.set_results({"stderr": _msg, "code": "1"})
             raise
 
     def rbd_map_image(self, event):

--- a/src/charm.py
+++ b/src/charm.py
@@ -582,27 +582,47 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
         """
         _bench = bench_tools.BenchTools(self)
 
+        # Remove image if existing
+        logging.info("Removing rbd image if existing")
+        try:
+            _bench.rbd_remove_image(
+                self.get_pool_name(event),
+            )
+            logging.info("rbd image removed")
+        except subprocess.CalledProcessError as e:
+            if "No such file or directory" in e.stderr.decode("UTF-8"):
+                pass
+            else:
+                _msg = ("rbd remove image failed: {}"
+                        .format(e.stderr.decode("UTF-8")))
+                logging.error(_msg)
+                event.fail(_msg)
+                event.set_results({"stderr": _msg, "code": "1"})
+                raise
+
         # Create the image
         logging.info("Create the rbd image")
         try:
+            extra_args = []
+            if event.params.get("ec-pool-name"):
+                extra_args = extra_args + \
+                    ["--data-pool", event.params.get("ec-pool-name")]
+
             _result = _bench.rbd_create_image(
                 self.get_pool_name(event),
-                event.params["image-size"])
+                event.params["image-size"],
+                extra_args
+            )
             # XXX We actually don't care about this output unless we fail on
             # subsequent steps
             event.set_results({self.action_output_key: _result})
         except subprocess.CalledProcessError as e:
-            if "already exists" in e.stderr.decode("UTF-8"):
-                logging.warning(e.stderr.decode("UTF-8"))
-            else:
-                _msg = ("rbd create image failed: {}"
-                        .format(e.stderr.decode("UTF-8")))
-                logging.error(_msg)
-                event.fail(_msg)
-                event.set_results({
-                    "stderr": _msg,
-                    "code": "1"})
-                raise
+            _msg = ("rbd create image failed: {}"
+                    .format(e.stderr.decode("UTF-8")))
+            logging.error(_msg)
+            event.fail(_msg)
+            event.set_results({"stderr": _msg, "code": "1"})
+            raise
 
     def rbd_map_image(self, event):
         """Create map and mount rbd block device.


### PR DESCRIPTION
Fixes [LP#194078: Need support for EC pools](https://bugs.launchpad.net/charm-woodpecker/+bug/1940478)

This patch adds optional parameter `ec-pool-name` to juju fio action. In case it is set then it is passed to rbd image creation command as an additional parameter `--data-pool <ec-pool-name>`

Since the rbd image can be created in different pools, this patch removes the rbd image if existing before creation.     

### Compiling and deploying
Required resource snap
```bash
git clone https://github.com/openstack-charmers/snap-swift-bench
cd snap-swift-bench
snapcraft --use-lxd
```

Deploying charm
```bash
# Ceph deployed
charmcraft pack
juju deploy ./woodpecker_ubuntu-20.04-amd64-s390x-ppc64el-arm64_ubuntu-22.04-amd64-s390x-ppc64el-arm64.charm woodpecker-gisr --to lxd:2 --bind oam
juju attach-resource woodpecker-gisr swift-bench=../snap-swift-bench/swift-bench_1.0_amd64.snap
juju add-relation woodpecker-gisr:prometheus-target  prometheus:target
juju add-relation woodpecker-gisr:ceph-client ceph-mon:client   
```

### Create EC pool
```bash
juju ssh ceph-mon/leader 

sudo su
K=6
M=3
FAILURE_DOMAIN=osd # AZ (osd|host|rack)
EC_POOL=ecpool_k${K}_m${M}

ceph osd erasure-code-profile set ${EC_POOL}_profile \
  crush-failure-domain=$FAILURE_DOMAIN \
  m=$M k=$K
ceph osd pool create ${EC_POOL} erasure ${EC_POOL}_profile
ceph osd pool set $EC_POOL allow_ec_overwrites true
ceph osd pool application enable $EC_POOL rbd
```

### Run FIO benchmarks
```bash
JOBS_PER_DISK=5
RUNTIME=300
# EC Pool
juju run-action --wait woodpecker-gisr/leader fio \                
   operation=randwrite block-size=4k num-jobs=$JOBS_PER_DISK runtime=$RUNTIME ec-pool-name=$EC_POOL
juju run-action --wait woodpecker-gisr/leader fio \
   operation=write block-size=4M num-jobs=$JOBS_PER_DISK runtime=$RUNTIME ec-pool-name=$EC_POOL

# RP pool
juju run-action --wait woodpecker-gisr/leader fio \                
   operation=randwrite block-size=4k num-jobs=$JOBS_PER_DISK runtime=$RUNTIME
juju run-action --wait woodpecker-gisr/leader fio \
   operation=write block-size=4M num-jobs=$JOBS_PER_DISK runtime=$RUNTIME
   
```

Benchmark outputs
> Left is EC 9+3. Right is default RP pool created by charm

1. randwrite/4k

![Screenshot from 2022-10-17 22-31-06](https://user-images.githubusercontent.com/40648663/196468281-70e3398b-f662-44dc-a7a5-ba39f4830244.png)

2. write/4M

![Screenshot from 2022-10-17 22-43-54](https://user-images.githubusercontent.com/40648663/196473211-78e5080a-d11b-4bb2-9a5d-681e4c1d89b0.png)
