### PR TITLE
Fix charm support on Jammy 

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,7 +17,7 @@ parts:
 bases:
   - build-on:
       - name: ubuntu
-        channel: "22.04"
+        channel: "20.04"
         architectures:
           - amd64
     run-on:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@ parts:
   charm:
     after: [update-certificates]
     build-packages: [python3-markupsafe, git]
-    charm-python-packages: [setuptools < 58]
+    charm-python-packages: [setuptools]
 
   update-certificates:
     plugin: nil
@@ -17,7 +17,7 @@ parts:
 bases:
   - build-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
         architectures:
           - amd64
     run-on:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,7 @@ tags:
   - openstack
 series:
   - focal
-  - bionic
+  - jammy
 subordinate: false
 min-juju-version: 2.7.6
 resources:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,8 +8,8 @@ tags:
   - ceph
   - openstack
 series:
-  - focal
   - jammy
+  - focal
 subordinate: false
 min-juju-version: 2.7.6
 resources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # requirements
-Jinja2<=2.10.1
+Jinja2
 PyYAML<=5.2
 netaddr<=0.7.19
 prometheus_client
-git+https://github.com/juju/charm-helpers.git@87fc7ee5#egg=charmhelpers
+git+https://github.com/juju/charm-helpers.git@59f134b#egg=charmhelpers
 git+https://github.com/canonical/operator.git@0.8.0#egg=ops
-git+https://opendev.org/openstack/charm-ops-interface-ceph-client@cc10f29d4#egg=interface_ceph_client
+git+https://opendev.org/openstack/charm-ops-interface-ceph-client#egg=interface_ceph_client
 git+https://opendev.org/openstack/charm-ops-openstack#egg=ops_openstack
-git+https://opendev.org/openstack/charm-ops-interface-tls-certificates@2ec41b60#egg=ca_client
+git+https://opendev.org/openstack/charm-ops-interface-tls-certificates@f720af03a1

--- a/src/bench_tools.py
+++ b/src/bench_tools.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import os.path
 
 import charmhelpers.core.host as ch_host
 
@@ -22,6 +23,12 @@ class BenchTools():
         return _output.decode("UTF-8")
 
     def rbd_remove_image(self, pool_name):
+        # first unmap the image otherwise removing the image will fail
+        _rbd_name = f"/dev/rbd/{ pool_name }/{ self.charm_instance.RBD_IMAGE }"
+        if os.path.exists(_rbd_name):
+            _cmd = ["rbd", "unmap", _rbd_name]
+            _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
+
         _cmd = ["rbd", "remove", self.charm_instance.RBD_IMAGE,
                 "-p", pool_name, "-n", self.charm_instance.CEPH_CLIENT_NAME]
         _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)

--- a/src/charm.py
+++ b/src/charm.py
@@ -940,8 +940,14 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             )
             while (datetime.datetime.now() < test_end):
                 _result = json.loads(_bench.fio(_fio_conf))
+                if event.params["operation"] in ["read", "randread"]:
+                    metrics = ["read"]
+                elif event.params["operation"] in ["write", "randwrite"]:
+                    metrics = ["write"]
+                else:
+                    metrics = ["read", "write"]
                 for job in _result["jobs"]:
-                    for metric in ('read', 'write'):
+                    for metric in metrics:
                         bandwidth = job[metric]["bw"]
                         iops = job[metric]["iops"]
                         # lat_ns is broadly slat + clat so

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,12 @@ whitelist_externals =
     git
     add-to-archive.py
     bash
-passenv = HOME TERM CS_* OS_* TEST_*
+passenv =
+    HOME
+    TERM
+    CS_*
+    OS_*
+    TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:py35]
@@ -89,7 +94,9 @@ commands = {posargs}
 basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
 commands =
-    charmcraft build
+    charmcraft clean
+    charmcraft -v pack
+    charmcraft clean
 
 [testenv:func-noop]
 basepython = python3


### PR DESCRIPTION
This will allow the charm to be built and used on Jammy 22.04.

This fixes as well a change of behavior with RBD and how fio outputs its results in JSON on Jammy.