### PR TITLE
Thick-provision rbd images

### DIFF
--- a/src/bench_tools.py
+++ b/src/bench_tools.py
@@ -30,6 +30,7 @@ class BenchTools():
     def rbd_create_image(self, pool_name, image_size, extra_args=[]):
         _cmd = ["rbd", "create", self.charm_instance.RBD_IMAGE,
                 "--size", str(image_size), "-p", pool_name,
+                "--thick-provision",
                 "-n", self.charm_instance.CEPH_CLIENT_NAME] + extra_args
         _output = subprocess.check_output(_cmd, stderr=subprocess.PIPE)
         return _output.decode("UTF-8")


### PR DESCRIPTION
RBD volumes are thin-provisioned by default,
which can impact read benchmarks.

By switching to thick-provisioned images,
we force reading from disk.


Closes-Bug: https://bugs.launchpad.net/charm-woodpecker/+bug/2043167