### PR TITLE
Zero disk devices before benchmarks

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -81,7 +81,12 @@ fio:
   params:
     disk-devices:
       type: string
-      description: "If unset, use the charm default rbd device in the ceph pool or the block devices provided using test-devices storage. If set run fio, against the set disk. Space delimited list of devices."
+      description: |
+        If unset, use the charm default rbd device in the ceph pool or the block devices provided using test-devices storage.
+        If set run fio, against the set disk.
+        Space delimited list of devices.
+
+        WARNING: Be careful which devices are selected, as all data will be wiped from these devices during the test.
     pool-name:
       type: string
       description: "If using the default rbd device, name of ceph pool for test. Defaults to config option pool-name"

--- a/src/bench_tools.py
+++ b/src/bench_tools.py
@@ -125,3 +125,12 @@ class BenchTools():
                 _cmd, stderr=subprocess.PIPE).decode("UTF-8"))
 
         return _output
+
+
+def fill_zero(device: str):
+    cmd = ["dd", "if=/dev/zero", f"of={device}", "bs=4M", "oflag=sync"]
+    try:
+        subprocess.run(cmd, text=True, capture_output=True, check=True)
+    except subprocess.CalledProcessError as e:
+        if "No space left on device" not in e.stderr:
+            raise

--- a/src/charm.py
+++ b/src/charm.py
@@ -915,6 +915,15 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             event.params["ioengine"] = 'libaio'
             _fio_conf = str(self.DISK_FIO_CONF)
 
+            for device in event.params["disk_devices"]:
+                try:
+                    bench_tools.fill_zero(device)
+                except subprocess.CalledProcessError as e:
+                    msg = f"zeroing disk device {device} failed: {e.stderr}"
+                    event.fail(msg)
+                    event.set_results({"message": msg})
+                    return
+
         # Add action_parms to adapters
         self.set_action_params(event)
         # Individual test execution runtime


### PR DESCRIPTION
For disk devices provided by disk-devices to the fio action,
or devices provided by the `test-devices` storage with juju.

This ensures that the disk is fully initialised,
so any kind of thin-provisioning won't affect the benchmarks.

Also update the description with a warning.
Note that data would have previously been lost anyway by the fio test,
not just from zeroing the disk.
But either way, we should make it clear in the docs.

Closes-Bug: https://bugs.launchpad.net/charm-woodpecker/+bug/2043167

This is a follow up to #7 to cover more cases (#7 is about RBD images, this is about manually provided disks or disks provided from the storage option).