### PR TITLE
Fix rbd-bench action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -46,8 +46,8 @@ rbd-bench:
       description: "Size of the RBD image."
     operation:
       type: string
-      default: rand
-      description: "Operation: write, rand, or seq"
+      default: readwrite
+      description: "Operation: read, write or readwrite"
 swift-bench:
   description: "Run the swift bench performance test"
   params:

--- a/src/charm.py
+++ b/src/charm.py
@@ -723,7 +723,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             raise
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -579,7 +579,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
 
     def rbd_create_image(self, event):
@@ -660,7 +660,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             raise
 
@@ -688,7 +688,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             raise
 
@@ -810,7 +810,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             self.unit.status = ops.model.BlockedStatus(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             return
 
@@ -819,7 +819,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
                     "leader.")
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             return
 
@@ -885,7 +885,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
             raise
 
@@ -1023,7 +1023,7 @@ class WoodpeckerCharmBase(ops_openstack.core.OSBaseCharm):
             logging.error(_msg)
             event.fail(_msg)
             event.set_results({
-                "stderr": _msg,
+                "message": _msg,
                 "code": "1"})
 
     def _defer_once(self, event):


### PR DESCRIPTION
The 'rand' and 'seq' operations are not valid for the 'bench' command of the 'rbd' binary[1]. Switch instead to 'readwrite' as a default.

In addition, when failing, the 'stderr' key is reserved for Juju, so use the 'message' key instead.

1: 
```
~$ rbd help bench
usage: rbd bench [--pool <pool>] [--namespace <namespace>] [--image <image>] 
                 [--io-size <io-size>] [--io-threads <io-threads>] 
                 [--io-total <io-total>] [--io-pattern <io-pattern>] 
                 [--rw-mix-read <rw-mix-read>] --io-type <io-type> 
                 <image-spec> 

Simple benchmark.

Positional arguments
  <image-spec>         image specification
                       (example: [<pool-name>/[<namespace>/]]<image-name>)

Optional arguments
  -p [ --pool ] arg    pool name
  --namespace arg      namespace name
  --image arg          image name
  --io-size arg        IO size (in B/K/M/G) (< 4G) [default: 4K]
  --io-threads arg     ios in flight [default: 16]
  --io-total arg       total size for IO (in B/K/M/G/T) [default: 1G]
  --io-pattern arg     IO pattern (rand, seq, or full-seq) [default: seq]
  --rw-mix-read arg    read proportion in readwrite (<= 100) [default: 50]
  --io-type arg        IO type (read, write, or readwrite(rw))
```