### PR TITLE
Revert "Make template rendering take operation type into account"

### DIFF
--- a/templates/disk.fio
+++ b/templates/disk.fio
@@ -1,12 +1,7 @@
 {% if action_params %}
 [global]
 ioengine={{ action_params.ioengine }}
-{% if 'read' in action_params.operation %}
-iodepth=1
-time_based=1
-{% else %}
 iodepth={{ action_params.iodepth }}
-{% endif %}
 direct=1
 rw={{ action_params.operation }}
 random_generator=lfsr

--- a/templates/rbd.fio
+++ b/templates/rbd.fio
@@ -16,10 +16,5 @@ latency_window={{ action_params.latency_window }}
 latency_percentile={{ action_params.latency_percentile }}
 {% endif %}
 [rbd_iodepth32]
-{% if 'read' in action_params.operation %}
-iodepth=1
-time_based=1
-{% else %}
 iodepth={{ action_params.iodepth }}
-{% endif %}
 {% endif %}


### PR DESCRIPTION
This reverts commit 01d4c9a2675d31b5a7afeb483dd65451636405eb in #2.

Silently ignoring action_params.iodepth that is explicitly passed by an user without any feedback is not intuitive or user friendly. When somebody runs the action with block-size=4k iodepth=32 and operation=randwrite or randread, randwrite gives a better number than randread, which is surprising. But it's just because iodepth=1 was hardcoded for randread. That doesn't help to generate data for comparison.

Emptying the default value for iodepth by having a logic of recommendded values or allowing specifying "time_based" can be implemented separately without hard coding.

Closes-Bug: [#2057461](https://bugs.launchpad.net/charm-woodpecker/+bug/2057461)
Related-Bug: [#1940371](https://bugs.launchpad.net/charm-woodpecker/+bug/1940371)
Related-Bug: [#2043167](https://bugs.launchpad.net/charm-woodpecker/+bug/2043167)